### PR TITLE
fixed menu to correctly refer to tao instead of bitcoin testnet

### DIFF
--- a/vanitygen.c
+++ b/vanitygen.c
@@ -312,7 +312,7 @@ usage(const char *name)
 "-k            Keep pattern and continue search after finding a match\n"
 "-1            Stop after first match\n"
 "-N            Generate namecoin address\n"
-"-T            Generate bitcoin testnet address\n"
+"-T            Generate tao address\n"
 "-X <version>  Generate address with the given version\n"
 "-F <format>   Generate address with the given format (pubkey or script)\n"
 "-P <pubkey>   Specify base public key for piecewise key generation\n"


### PR DESCRIPTION
just because it confused me that -T was listed as bitcoin testnet instead of tao ;)